### PR TITLE
[CS-55]: Fix issue with Android crashing when too many messages are sent

### DIFF
--- a/CHANGE-LOG.md
+++ b/CHANGE-LOG.md
@@ -1,5 +1,7 @@
 # Full Change Log for Raygun4Maui package
 
+### v1.4.1
+- Fixed issue with resource locking of device environment information on Android causing app to crash
 ### v1.4.0
 - Dependency update to Raygun4Net 8.0.0
 

--- a/CHANGE-LOG.md
+++ b/CHANGE-LOG.md
@@ -2,6 +2,7 @@
 
 ### v1.4.1
 - Fixed issue with resource locking of device environment information on Android causing app to crash
+
 ### v1.4.0
 - Dependency update to Raygun4Net 8.0.0
 

--- a/Raygun4Maui/MauiUnhandledExceptions/MattJohnsonPint.Maui/MauiExceptions.cs
+++ b/Raygun4Maui/MauiUnhandledExceptions/MattJohnsonPint.Maui/MauiExceptions.cs
@@ -52,6 +52,7 @@ namespace Raygun4Maui.MattJohnsonPint.Maui
 
             Android.Runtime.AndroidEnvironment.UnhandledExceptionRaiser += (sender, args) =>
             {
+                args.Handled = true;
                 UnhandledException?.Invoke(sender, new UnhandledExceptionEventArgs(args.Exception, true));
             };
 

--- a/Raygun4Maui/MauiUnhandledExceptions/RaygunMauiUnhandledExceptionsExtensions.cs
+++ b/Raygun4Maui/MauiUnhandledExceptions/RaygunMauiUnhandledExceptionsExtensions.cs
@@ -26,7 +26,7 @@ namespace Raygun4Maui.MauiUnhandledExceptions
                 {
                     tags.Add(Raygun4NetBuildPlatforms.GetBuildPlatform());
                 }
-                RaygunMauiClient.Current.Send(e, tags, null);
+                RaygunMauiClient.Current.SendInBackground(e, tags, null);
             };
         }
     }

--- a/Raygun4Maui/MauiUnhandledExceptions/RaygunMauiUnhandledExceptionsExtensions.cs
+++ b/Raygun4Maui/MauiUnhandledExceptions/RaygunMauiUnhandledExceptionsExtensions.cs
@@ -1,4 +1,5 @@
-﻿using Raygun4Maui.MattJohnsonPint.Maui;
+﻿using System.Diagnostics;
+using Raygun4Maui.MattJohnsonPint.Maui;
 using Raygun4Net.BuildPlatforms;
 
 namespace Raygun4Maui.MauiUnhandledExceptions
@@ -8,7 +9,7 @@ namespace Raygun4Maui.MauiUnhandledExceptions
         internal static MauiAppBuilder AddRaygunUnhandledExceptionsListener(
             this MauiAppBuilder mauiAppBuilder,
             Raygun4MauiSettings raygunMauiSettings
-            )
+        )
         {
             AttachMauiExceptionHandler(raygunMauiSettings);
 
@@ -19,14 +20,22 @@ namespace Raygun4Maui.MauiUnhandledExceptions
         {
             MauiExceptions.UnhandledException += (sender, args) =>
             {
-                Exception e = (Exception)args.ExceptionObject;
-                List<string> tags = new List<string>() { "UnhandledException" };
-
-                if (raygunMauiSettings.SendDefaultTags)
+                try
                 {
-                    tags.Add(Raygun4NetBuildPlatforms.GetBuildPlatform());
+                    Exception e = (Exception)args.ExceptionObject;
+                    List<string> tags = new List<string>() { "UnhandledException" };
+
+                    if (raygunMauiSettings.SendDefaultTags)
+                    {
+                        tags.Add(Raygun4NetBuildPlatforms.GetBuildPlatform());
+                    }
+                    
+                    RaygunMauiClient.Current.SendInBackground(e, tags, null);
                 }
-                RaygunMauiClient.Current.SendInBackground(e, tags, null);
+                catch (Exception e)
+                {
+                    Trace.TraceError($"Unhandled exception handler had an error: {e.Message}");
+                }
             };
         }
     }

--- a/Raygun4Maui/Raygun4Maui.csproj
+++ b/Raygun4Maui/Raygun4Maui.csproj
@@ -17,7 +17,7 @@
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'tizen'">6.5</SupportedOSPlatformVersion>
 		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
 		<Version>1.4.1</Version>
-		<PackageVersion>1.4.1-pre-1</PackageVersion>
+		<PackageVersion>1.4.1</PackageVersion>
 		<Authors>Raygun</Authors>
 		<Company>Raygun</Company>
 		<PackageReadmeFile>README.md</PackageReadmeFile>

--- a/Raygun4Maui/Raygun4Maui.csproj
+++ b/Raygun4Maui/Raygun4Maui.csproj
@@ -16,8 +16,8 @@
 		<TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</TargetPlatformMinVersion>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'tizen'">6.5</SupportedOSPlatformVersion>
 		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-		<Version>1.4.0</Version>
-		<PackageVersion>1.4.0</PackageVersion>
+		<Version>1.4.1</Version>
+		<PackageVersion>1.4.1</PackageVersion>
 		<Authors>Raygun</Authors>
 		<Company>Raygun</Company>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
@@ -26,18 +26,7 @@
 		<PackageProjectUrl>https://raygun.com/platform/crash-reporting</PackageProjectUrl>
 		<RepositoryUrl>https://github.com/MindscapeHQ/raygun4maui</RepositoryUrl>
 		<PackageTags>Raygun4Maui; Raygun; Crash Reporting; MAUI; .NET; dotnet</PackageTags>
-		<PackageReleaseNotes>Expanded the device information that is collected when a crash is sent to Raygun.
-The new information collected is as follows:
-- Available physical memory
-- Total physical memory
-- Processor count
-- Architecture
-- Device manugacture
-- Model
-- Current orientation
-- Resolution scale
-- WindowBoundsWidth
-- WindowBoundsHeight</PackageReleaseNotes>
+		<PackageReleaseNotes>Fix issue with UI thread blocking on unhandled exceptions</PackageReleaseNotes>
 		<Title>Raygun4Maui</Title>
 		<PackageLicenseFile>LICENSE</PackageLicenseFile>
 		<PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>

--- a/Raygun4Maui/Raygun4Maui.csproj
+++ b/Raygun4Maui/Raygun4Maui.csproj
@@ -16,7 +16,7 @@
 		<TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</TargetPlatformMinVersion>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'tizen'">6.5</SupportedOSPlatformVersion>
 		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-		<Version>1.4.1-pre-1</Version>
+		<Version>1.4.1</Version>
 		<PackageVersion>1.4.1-pre-1</PackageVersion>
 		<Authors>Raygun</Authors>
 		<Company>Raygun</Company>

--- a/Raygun4Maui/Raygun4Maui.csproj
+++ b/Raygun4Maui/Raygun4Maui.csproj
@@ -16,8 +16,8 @@
 		<TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</TargetPlatformMinVersion>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'tizen'">6.5</SupportedOSPlatformVersion>
 		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-		<Version>1.4.1</Version>
-		<PackageVersion>1.4.1</PackageVersion>
+		<Version>1.4.1-pre-1</Version>
+		<PackageVersion>1.4.1-pre-1</PackageVersion>
 		<Authors>Raygun</Authors>
 		<Company>Raygun</Company>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
@@ -26,7 +26,7 @@
 		<PackageProjectUrl>https://raygun.com/platform/crash-reporting</PackageProjectUrl>
 		<RepositoryUrl>https://github.com/MindscapeHQ/raygun4maui</RepositoryUrl>
 		<PackageTags>Raygun4Maui; Raygun; Crash Reporting; MAUI; .NET; dotnet</PackageTags>
-		<PackageReleaseNotes>Fix issue with messages being sent too fast causing Android to crash</PackageReleaseNotes>
+		<PackageReleaseNotes>https://github.com/MindscapeHQ/raygun4maui/blob/master/CHANGE-LOG.md</PackageReleaseNotes>
 		<Title>Raygun4Maui</Title>
 		<PackageLicenseFile>LICENSE</PackageLicenseFile>
 		<PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>

--- a/Raygun4Maui/Raygun4Maui.csproj
+++ b/Raygun4Maui/Raygun4Maui.csproj
@@ -26,7 +26,7 @@
 		<PackageProjectUrl>https://raygun.com/platform/crash-reporting</PackageProjectUrl>
 		<RepositoryUrl>https://github.com/MindscapeHQ/raygun4maui</RepositoryUrl>
 		<PackageTags>Raygun4Maui; Raygun; Crash Reporting; MAUI; .NET; dotnet</PackageTags>
-		<PackageReleaseNotes>Fix issue with UI thread blocking on unhandled exceptions</PackageReleaseNotes>
+		<PackageReleaseNotes>Fix issue with messages being sent too fast causing Android to crash</PackageReleaseNotes>
 		<Title>Raygun4Maui</Title>
 		<PackageLicenseFile>LICENSE</PackageLicenseFile>
 		<PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>

--- a/Raygun4Maui/Raygun4Net.BuildPlatforms/RaygunPlatforms.cs
+++ b/Raygun4Maui/Raygun4Net.BuildPlatforms/RaygunPlatforms.cs
@@ -1,4 +1,6 @@
-﻿namespace Raygun4Net.BuildPlatforms
+﻿// Namespace is different, doesn't include Raygun4Maui because we may want to move this to Raygun4Net
+// ReSharper disable once CheckNamespace
+namespace Raygun4Net.BuildPlatforms
 {
     public static class Raygun4NetBuildPlatforms
     {

--- a/Raygun4Maui/Raygun4Net.RaygunLogger/RaygunLogger.cs
+++ b/Raygun4Maui/Raygun4Net.RaygunLogger/RaygunLogger.cs
@@ -2,6 +2,8 @@
 using Raygun4Net.BuildPlatforms;
 using Raygun4Maui;
 
+// Namespace is different, doesn't include Raygun4Maui because we may want to move this to Raygun4Net
+// ReSharper disable once CheckNamespace
 namespace Raygun4Net.RaygunLogger
 {
     public sealed class RaygunLogger : ILogger

--- a/Raygun4Maui/Raygun4Net.RaygunLogger/RaygunLoggerConfiguration.cs
+++ b/Raygun4Maui/Raygun4Net.RaygunLogger/RaygunLoggerConfiguration.cs
@@ -1,6 +1,8 @@
 ﻿using Microsoft.Extensions.Logging;
 using Mindscape.Raygun4Net;
 
+// Namespace is different, doesn't include Raygun4Maui because we may want to move this to Raygun4Net
+// ReSharper disable once CheckNamespace
 namespace Raygun4Net.RaygunLogger
 {
     public class RaygunLoggerConfiguration : RaygunSettings

--- a/Raygun4Maui/Raygun4Net.RaygunLogger/RaygunLoggerMauiExtensions.cs
+++ b/Raygun4Maui/Raygun4Net.RaygunLogger/RaygunLoggerMauiExtensions.cs
@@ -2,6 +2,8 @@
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
 
+// Namespace is different, doesn't include Raygun4Maui because we may want to move this to Raygun4Net
+// ReSharper disable once CheckNamespace
 namespace Raygun4Net.RaygunLogger
 {
     public static class RaygunLoggerMauiExtensions

--- a/Raygun4Maui/Raygun4Net.RaygunLogger/RaygunLoggerProvider.cs
+++ b/Raygun4Maui/Raygun4Net.RaygunLogger/RaygunLoggerProvider.cs
@@ -2,6 +2,8 @@
 using Microsoft.Extensions.Options;
 using System.Collections.Concurrent;
 
+// Namespace is different, doesn't include Raygun4Maui because we may want to move this to Raygun4Net
+// ReSharper disable once CheckNamespace
 namespace Raygun4Net.RaygunLogger
 {
     public sealed class RaygunLoggerProvider : ILoggerProvider

--- a/Raygun4Maui/RaygunMauiClient.cs
+++ b/Raygun4Maui/RaygunMauiClient.cs
@@ -1,4 +1,3 @@
-
 using System.Reflection;
 using Mindscape.Raygun4Net;
 using System.Globalization;
@@ -11,9 +10,16 @@ namespace Raygun4Maui
         private static RaygunMauiClient _instance;
         public static RaygunMauiClient Current => _instance;
 
+        private static readonly object EnvironmentLock = new();
+
         private static readonly string Name = Assembly.GetExecutingAssembly().GetName().Name;
-        private static readonly string Version = Assembly.GetExecutingAssembly().GetName().Version.ToString();
-        private static readonly string ClientUrl = "https://github.com/MindscapeHQ/raygun4maui"; //It does not seem like this can be obtained automatically
+
+        private static readonly string Version =
+            Assembly.GetExecutingAssembly().GetName().Version?.ToString() ?? "Unknown";
+
+        private static readonly string
+            ClientUrl =
+                "https://github.com/MindscapeHQ/raygun4maui"; //It does not seem like this can be obtained automatically
 
         public static readonly RaygunClientMessage clientMessage = new()
         {
@@ -21,46 +27,55 @@ namespace Raygun4Maui
             Version = Version,
             ClientUrl = ClientUrl
         };
+
         internal static void Attach(RaygunMauiClient client)
         {
             if (_instance != null)
             {
                 throw new Exception("You should only call 'AddRaygun4maui' once in your app.");
             }
-          
+
             _instance = client;
         }
+
         public RaygunMauiClient(string apiKey) : base(apiKey)
         {
-
         }
 
         public RaygunMauiClient(RaygunSettings settings) : base(settings)
         {
+            System.Diagnostics.Debug.WriteLine("RAYGUN4MAUI CREATED");
         }
 
-        
-
-        protected override async Task<RaygunMessage> BuildMessage(Exception exception, IList<string> tags, IDictionary userCustomData, RaygunIdentifierMessage userInfo)
+        protected override async Task<RaygunMessage> BuildMessage(Exception exception, IList<string> tags,
+            IDictionary userCustomData, RaygunIdentifierMessage userInfo)
         {
-            DateTime now = DateTime.Now;
-            var environment = new RaygunMauiEnvironmentMessage //Mostlikely should be static
+            RaygunMauiEnvironmentMessage environment;
+            lock (EnvironmentLock)
             {
-                UtcOffset = TimeZoneInfo.Local.GetUtcOffset(now).TotalHours,
-                Locale = CultureInfo.CurrentCulture.DisplayName,
-                OSVersion = DeviceInfo.Current.VersionString,
-                Architecture = NativeDeviceInfo.Architecture(),
-                WindowBoundsWidth = DeviceDisplay.MainDisplayInfo.Width,
-                WindowBoundsHeight = DeviceDisplay.MainDisplayInfo.Height,
-                DeviceManufacturer = DeviceInfo.Current.Manufacturer,
-                Platform = NativeDeviceInfo.Platform(),
-                Model = DeviceInfo.Current.Model,
-                ProcessorCount = Environment.ProcessorCount,
-                ResolutionScale = DeviceDisplay.MainDisplayInfo.Density,
-                TotalPhysicalMemory = NativeDeviceInfo.TotalPhysicalMemory(),
-                AvailablePhysicalMemory = NativeDeviceInfo.AvailablePhysicalMemory(),
-                CurrentOrientation = DeviceDisplay.MainDisplayInfo.Orientation.ToString(),
-            };
+                DateTime now = DateTime.Now;
+
+                environment = new RaygunMauiEnvironmentMessage //Mostlikely should be static
+                {
+                    // Combination of these cause the error, it may happen with the other ones too
+                    UtcOffset = TimeZoneInfo.Local.GetUtcOffset(now).TotalHours, // Not this,
+                    Locale = CultureInfo.CurrentCulture.DisplayName, // Not this,
+                    OSVersion = DeviceInfo.Current.VersionString, // Not This,
+                    Architecture = NativeDeviceInfo.Architecture(), // Not This,
+                    WindowBoundsWidth = DeviceDisplay.MainDisplayInfo.Width, // <------ THIS!!
+                    
+                    
+                    WindowBoundsHeight = DeviceDisplay.MainDisplayInfo.Height,
+                    DeviceManufacturer = DeviceInfo.Current.Manufacturer,
+                    Platform = NativeDeviceInfo.Platform(),
+                    Model = DeviceInfo.Current.Model,
+                    ProcessorCount = Environment.ProcessorCount, 
+                    ResolutionScale = DeviceDisplay.MainDisplayInfo.Density,
+                    TotalPhysicalMemory = NativeDeviceInfo.TotalPhysicalMemory(),
+                    AvailablePhysicalMemory = NativeDeviceInfo.AvailablePhysicalMemory(),
+                    CurrentOrientation = DeviceDisplay.MainDisplayInfo.Orientation.ToString(),
+                };
+            }
 
             var details = new RaygunMessageDetails
             {
@@ -70,7 +85,8 @@ namespace Raygun4Maui
                 UserCustomData = userCustomData,
                 Tags = tags,
                 Version = ApplicationVersion,
-                User = userInfo ?? UserInfo ?? (!String.IsNullOrEmpty(User) ? new RaygunIdentifierMessage(User) : null),
+                User = userInfo ??
+                       UserInfo ?? (!String.IsNullOrEmpty(User) ? new RaygunIdentifierMessage(User) : null),
                 Environment = environment
             };
 
@@ -90,4 +106,4 @@ namespace Raygun4Maui
             return message;
         }
     }
-} 
+}

--- a/Raygun4Maui/RaygunMauiEnvironmentMessageBuilder.cs
+++ b/Raygun4Maui/RaygunMauiEnvironmentMessageBuilder.cs
@@ -1,0 +1,53 @@
+﻿using System.Globalization;
+
+namespace Raygun4Maui;
+
+internal class RaygunMauiEnvironmentMessageBuilder
+{
+    private static readonly object EnvironmentLock = new();
+
+    public string OSVersion { get; init; } = DeviceInfo.Current.VersionString; 
+    public string Architecture { get; init; } = NativeDeviceInfo.Architecture(); 
+
+    private string DeviceManufacturer = DeviceInfo.Current.Manufacturer;
+    private string Platform = NativeDeviceInfo.Platform();
+    private string Model = DeviceInfo.Current.Model;
+
+    private int ProcessorCount = Environment.ProcessorCount;
+
+
+    private ulong TotalPhysicalMemory = NativeDeviceInfo.TotalPhysicalMemory();
+    
+    internal RaygunMauiEnvironmentMessage BuildEnvironmentMessage()
+    {
+        // We create a lock so that during async tasks we do not access device information at the same time
+        // this has caused issues in Android
+        lock (EnvironmentLock)
+        {
+            DateTime now = DateTime.Now;
+
+            return new RaygunMauiEnvironmentMessage
+            {
+                UtcOffset = TimeZoneInfo.Local.GetUtcOffset(DateTime.Now).TotalHours,
+                Locale = CultureInfo.CurrentCulture.DisplayName,
+                OSVersion = OSVersion,
+                Architecture = Architecture,
+                WindowBoundsWidth = DeviceDisplay.MainDisplayInfo.Width,
+                WindowBoundsHeight = DeviceDisplay.MainDisplayInfo.Height,
+                DeviceManufacturer = DeviceInfo.Current.Manufacturer,
+                Platform = Platform,
+                Model = Model,
+                ProcessorCount = ProcessorCount,
+                ResolutionScale = DeviceDisplay.MainDisplayInfo.Density,
+                TotalPhysicalMemory = TotalPhysicalMemory,
+                AvailablePhysicalMemory = NativeDeviceInfo.AvailablePhysicalMemory(),
+                CurrentOrientation = DeviceDisplay.MainDisplayInfo.Orientation.ToString(),
+            };
+        }
+    }
+
+    public static RaygunMauiEnvironmentMessageBuilder Init()
+    {
+        return new RaygunMauiEnvironmentMessageBuilder();
+    }
+}


### PR DESCRIPTION
Ticket: [CS-55](https://raygun.atlassian.net/browse/CS-55)
## Description:
Original issue was that Telerik + Raygun4Maui was crashing on startup on Android. This was able to be reproduced without Telerik with a spam of logs (Telerik was sending ~15 warning logs). The root cause was in the creation of the environment message to be attached to the crash report, when multiple threads would access environment information the JNI would panic due to a global reference not existing (specifics are still unclear). 

The solution to this is to put a lock on to the creation of the message. I have moved this into its own message builder class so that it is separated from the RaygunMauiClient.
 
## Test plan:
- Create a surge of log or error requests (>5) while running on Android
- Ensure that the app does not crash and that the Raygun app receives the crash reports

### Author to check:
- [ ] Builds pass
- [ ] Tested in an alternative environment
- [ ] Reviewed by another developer
- [ ] Appropriate documentation written
### Reviewer to check:
- [ ] Code is written to standards
- [ ] Appropriate tests have been written
- [ ] Version is correct (we will pre-release first to ensure this is a viable fix)