### PR TITLE
Subscribe to TaskScheduler.UnobservedTaskException as well

### DIFF
--- a/Raygun4Maui/MauiUnhandledExceptions/MattJohnsonPint.Maui/MauiExceptions.cs
+++ b/Raygun4Maui/MauiUnhandledExceptions/MattJohnsonPint.Maui/MauiExceptions.cs
@@ -31,6 +31,12 @@ namespace Raygun4Maui.MattJohnsonPint.Maui
                 UnhandledException?.Invoke(sender, args);
             };
 
+             // Events fired by the TaskScheduler. That is calls like Task.Run(...)     
+            TaskScheduler.UnobservedTaskException += (sender, args) => 
+            {
+                UnhandledException?.Invoke(sender, new UnhandledExceptionEventArgs(args.Exception, false));
+            };
+
 #if IOS || MACCATALYST
 
             // For iOS and Mac Catalyst

--- a/Raygun4Maui/MauiUnhandledExceptions/MattJohnsonPint.Maui/MauiExceptions.cs
+++ b/Raygun4Maui/MauiUnhandledExceptions/MattJohnsonPint.Maui/MauiExceptions.cs
@@ -31,7 +31,7 @@ namespace Raygun4Maui.MattJohnsonPint.Maui
                 UnhandledException?.Invoke(sender, args);
             };
 
-             // Events fired by the TaskScheduler. That is calls like Task.Run(...)     
+            // Events fired by the TaskScheduler. That is calls like Task.Run(...)     
             TaskScheduler.UnobservedTaskException += (sender, args) => 
             {
                 UnhandledException?.Invoke(sender, new UnhandledExceptionEventArgs(args.Exception, false));


### PR DESCRIPTION
Tasks that do not handle exceptions should also be reported as UnhandledException.
The MauiExceptions.cs file did not have this, but it is a valuable exception to report
as typically there would be no in-app indication/crash if any exceptions were thrown
in Tasks that are not await-ed or Wait()-ed.

The original has some comments:
https://gist.github.com/mattjohnsonpint/7b385b7a2da7059c4a16562bc5ddb3b7?permalink_comment_id=4710633#gistcomment-4710633

This code is based on the updated gist: https://gist.github.com/myrup/43ee8038e0fd6ef4d31cbdd67449a997#file-mauiexceptions-cs-L21-L25

My suggestion that I opened: https://raygun.com/thinktank/suggestion/185362