### PR TITLE
Fix SendInBackground for iOS

### DIFF
--- a/CHANGE-LOG.md
+++ b/CHANGE-LOG.md
@@ -1,5 +1,8 @@
 # Full Change Log for Raygun4Maui package
 
+### v1.4.2
+- Fixed issue with SendInBackground where environment variables are collected on the wrong thread causing it to fail silently
+
 ### v1.4.1
 - Fixed issue with resource locking of device environment information on Android causing app to crash
 

--- a/Raygun4Maui.SampleApp/Raygun4Maui.SampleApp.csproj
+++ b/Raygun4Maui.SampleApp/Raygun4Maui.SampleApp.csproj
@@ -85,13 +85,11 @@
 	  <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="7.0.0" />
 	  <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.1" />
 	  <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="7.0.0" />
-	  <PackageReference Include="Raygun4Maui" Version="1.4.2-pre-1" />
 	  <PackageReference Include="Serilog.Sinks.Raygun" Version="7.3.0" />
-		
 	</ItemGroup>
 
-<!--	 <ItemGroup> -->
-<!--	   <ProjectReference Include="..\Raygun4Maui\Raygun4Maui.csproj" /> -->
-<!--	 </ItemGroup> -->
+	 <ItemGroup> 
+	   <ProjectReference Include="..\Raygun4Maui\Raygun4Maui.csproj" /> 
+	 </ItemGroup> 
 
 </Project>

--- a/Raygun4Maui.SampleApp/Raygun4Maui.SampleApp.csproj
+++ b/Raygun4Maui.SampleApp/Raygun4Maui.SampleApp.csproj
@@ -85,11 +85,13 @@
 	  <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="7.0.0" />
 	  <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.1" />
 	  <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="7.0.0" />
+	  <PackageReference Include="Raygun4Maui" Version="1.4.2-pre-1" />
 	  <PackageReference Include="Serilog.Sinks.Raygun" Version="7.3.0" />
+		
 	</ItemGroup>
 
-	 <ItemGroup> 
-	   <ProjectReference Include="..\Raygun4Maui\Raygun4Maui.csproj" /> 
-	 </ItemGroup> 
+<!--	 <ItemGroup> -->
+<!--	   <ProjectReference Include="..\Raygun4Maui\Raygun4Maui.csproj" /> -->
+<!--	 </ItemGroup> -->
 
 </Project>

--- a/Raygun4Maui/MauiUnhandledExceptions/RaygunMauiUnhandledExceptionsExtensions.cs
+++ b/Raygun4Maui/MauiUnhandledExceptions/RaygunMauiUnhandledExceptionsExtensions.cs
@@ -30,7 +30,7 @@ namespace Raygun4Maui.MauiUnhandledExceptions
                         tags.Add(Raygun4NetBuildPlatforms.GetBuildPlatform());
                     }
                     
-                    RaygunMauiClient.Current.SendInBackground(e, tags, null);
+                    RaygunMauiClient.Current.Send(e, tags, null);
                 }
                 catch (Exception e)
                 {

--- a/Raygun4Maui/Raygun4Maui.csproj
+++ b/Raygun4Maui/Raygun4Maui.csproj
@@ -16,8 +16,8 @@
 		<TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</TargetPlatformMinVersion>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'tizen'">6.5</SupportedOSPlatformVersion>
 		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-		<Version>1.4.1</Version>
-		<PackageVersion>1.4.1</PackageVersion>
+		<Version>1.4.2</Version>
+		<PackageVersion>1.4.2-pre-1</PackageVersion>
 		<Authors>Raygun</Authors>
 		<Company>Raygun</Company>
 		<PackageReadmeFile>README.md</PackageReadmeFile>

--- a/Raygun4Maui/Raygun4Maui.csproj
+++ b/Raygun4Maui/Raygun4Maui.csproj
@@ -17,7 +17,7 @@
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'tizen'">6.5</SupportedOSPlatformVersion>
 		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
 		<Version>1.4.2</Version>
-		<PackageVersion>1.4.2-pre-1</PackageVersion>
+		<PackageVersion>1.4.2</PackageVersion>
 		<Authors>Raygun</Authors>
 		<Company>Raygun</Company>
 		<PackageReadmeFile>README.md</PackageReadmeFile>

--- a/Raygun4Maui/RaygunMauiClient.cs
+++ b/Raygun4Maui/RaygunMauiClient.cs
@@ -10,11 +10,8 @@ namespace Raygun4Maui
         private static RaygunMauiClient _instance;
         public static RaygunMauiClient Current => _instance;
 
-        private readonly Lazy<RaygunMauiEnvironmentMessageBuilder> _lazyMessageBuilder =
-            new Lazy<RaygunMauiEnvironmentMessageBuilder>(RaygunMauiEnvironmentMessageBuilder.Init);
-
-        private RaygunMauiEnvironmentMessageBuilder EnvironmentMessageBuilder => _lazyMessageBuilder.Value;
-
+        private readonly RaygunMauiEnvironmentMessageBuilder _environmentMessageBuilder = new();
+        
         private static readonly string Name = Assembly.GetExecutingAssembly().GetName().Name;
 
         private static readonly string Version =
@@ -53,7 +50,7 @@ namespace Raygun4Maui
         protected override async Task<RaygunMessage> BuildMessage(Exception exception, IList<string> tags,
             IDictionary userCustomData, RaygunIdentifierMessage userInfo)
         {
-            var environment = EnvironmentMessageBuilder.BuildEnvironmentMessage();
+            var environment = _environmentMessageBuilder.BuildEnvironmentMessage();
 
             var details = new RaygunMessageDetails
             {

--- a/Raygun4Maui/RaygunMauiEnvironmentMessageBuilder.cs
+++ b/Raygun4Maui/RaygunMauiEnvironmentMessageBuilder.cs
@@ -30,6 +30,14 @@ internal class RaygunMauiEnvironmentMessageBuilder
 
     private string CurrentOrientation = null;
 
+    public RaygunMauiEnvironmentMessageBuilder()
+    {
+        DeviceDisplay.MainDisplayInfoChanged += UpdateDisplayInfo;
+
+        // Ensure that we do have assigned values to the display fields by manually sending an update with the current information
+        MainThread.InvokeOnMainThreadAsync(() => UpdateDisplayInfo(this, new DisplayInfoChangedEventArgs(DeviceDisplay.MainDisplayInfo)));
+    }
+    
     internal RaygunMauiEnvironmentMessage BuildEnvironmentMessage()
     {
         return new RaygunMauiEnvironmentMessage
@@ -60,13 +68,5 @@ internal class RaygunMauiEnvironmentMessageBuilder
         WindowBoundsHeight = args.DisplayInfo.Height;
         ResolutionScale = args.DisplayInfo.Density;
         CurrentOrientation = args.DisplayInfo.Orientation.ToString();
-    }
-
-    public RaygunMauiEnvironmentMessageBuilder()
-    {
-        DeviceDisplay.MainDisplayInfoChanged += UpdateDisplayInfo;
-
-        // Instantiated here as RaygunMauiEnvironmentMessageBuilder is lazily initialised so we can be sure the DeviceDisplay has an instance
-        MainThread.InvokeOnMainThreadAsync(() => UpdateDisplayInfo(this, new DisplayInfoChangedEventArgs(DeviceDisplay.MainDisplayInfo)));
     }
 }


### PR DESCRIPTION
Issue:
During the creation of the RaygunEnvironmentMessage on iOS some fields require that they are accessed on the Main/UI thread. Previously, the provider was silently failing on this and the crash report would never be send to Raygun. This would also cause an infinite loop if ThrowOnError was enabled.


Fix:
Construct the RaygunEnvironmentMessage on the Main/UI thread and then hand back to the thread the SendInBackground call is using.


Testing:
- Confirmed <= v1.4.1 does not send crash report on iOS when using SendInBackground
- Applied MainThread.InvokeOnMainThreadAsync change
- Confirmed that SendInBackground works on iOS, additionally, tested that it still works on Android and other platforms 