### PR TITLE
Version Bump to Fix Issue Where Unhandled Exceptions Were Not Reported Sometiems

### DIFF
--- a/CHANGE-LOG.md
+++ b/CHANGE-LOG.md
@@ -1,5 +1,11 @@
 # Full Change Log for Raygun4Maui package
 
+### v2.0.1
+Version bump to Raygun4Net.NetCore v10.1.2
+- Fix issue where uncaught exceptions could sometimes not be reported to Raygun
+  - See: https://github.com/MindscapeHQ/raygun4net/pull/529
+  - Keeps a strong reference to the `OnApplicationUnhandledException` delegate in the client so that reference is alive as long as the client is
+
 ### v2.0.0
 Adds support for Real User Monitoring (RUM) for Windows, Android, iOS, and MacCatalyst
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ dotnet add package Raygun4Maui
 
 Alternatively, you can specify a version tag to install a specific version of the package. See [Raygun4Maui NuGet Gallery page](https://nuget.org/packages/Raygun4Maui) for information on available versions.
 ```
-dotnet add package Raygun4Maui --version 1.2.1
+dotnet add package Raygun4Maui --version 2.0.1
 ```
 
 ### Step 2 - Add Raygun4Maui to your MauiApp builder

--- a/Raygun4Maui/Raygun4Maui.csproj
+++ b/Raygun4Maui/Raygun4Maui.csproj
@@ -16,16 +16,16 @@
         <TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</TargetPlatformMinVersion>
         <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'tizen'">6.5</SupportedOSPlatformVersion>
         <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-        <Version>2.0.0</Version>
-        <PackageVersion>2.0.0</PackageVersion>
+        <Version>2.0.1</Version>
+        <PackageVersion>2.0.1</PackageVersion>
         <Authors>Raygun</Authors>
         <Company>Raygun</Company>
         <PackageReadmeFile>README.md</PackageReadmeFile>
-        <Description>Raygun's Crash Reporting Provider for MAUI .NET</Description>
+        <Description>Raygun's Crash Reporting and Real User Monitoring Provider for MAUI .NET</Description>
         <Copyright>Copyright (C) 2024 Raygun Limited</Copyright>
         <PackageProjectUrl>https://raygun.com/platform/crash-reporting</PackageProjectUrl>
         <RepositoryUrl>https://github.com/MindscapeHQ/raygun4maui</RepositoryUrl>
-        <PackageTags>Raygun4Maui; Raygun; Crash Reporting; MAUI; .NET; dotnet</PackageTags>
+        <PackageTags>Raygun4Maui; Raygun; Crash Reporting; MAUI; .NET; dotnet; Real User Monitoring</PackageTags>
         <PackageReleaseNotes>https://github.com/MindscapeHQ/raygun4maui/blob/master/CHANGE-LOG.md</PackageReleaseNotes>
         <Title>Raygun4Maui</Title>
         <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>

--- a/Raygun4Maui/Raygun4Maui.csproj
+++ b/Raygun4Maui/Raygun4Maui.csproj
@@ -106,7 +106,7 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.1"/>
-        <PackageReference Include="Mindscape.Raygun4Net.NetCore" Version="10.1.0" />
+        <PackageReference Include="Mindscape.Raygun4Net.NetCore" Version="10.1.2" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net7.0-android'">


### PR DESCRIPTION
Bumps version of Raygun4Net.NetCore to v10.1.2 to fix an issue with unhandled exceptions not being reported sometimes


See: https://github.com/MindscapeHQ/raygun4net/pull/529