### PR TITLE
[Fix] Throttled background sender thread usage and offline storage

### DIFF
--- a/CHANGE-LOG.md
+++ b/CHANGE-LOG.md
@@ -1,5 +1,13 @@
 # Full Change Log for Raygun4Maui package
 
+### v2.2.0
+- Version bump to `Raygun4Net.NetCore v11.1.0`
+  - Implements dynamic thread allocation when error spikes occurs
+    - Fixes static thread allocation which caused performance issues on .NET Core and MAUI apps
+  - Removes errors stuck in a 4xx loop when stored in the offline storage 
+    - Edge case allowed for errors that should have been 4xx to put into offline storage and infinitely loop
+    - Large errors would also make concurrent GC heap freed messages in the console
+
 ### v2.1.2
 - Version bump to `Raygun4Net.NetCore v11.0.3`
   - Fixes the null signature issue when Debug Symbols are set to None and the application is built in Release mode.

--- a/Raygun4Maui/Raygun4Maui.csproj
+++ b/Raygun4Maui/Raygun4Maui.csproj
@@ -16,8 +16,8 @@
         <TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</TargetPlatformMinVersion>
         <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'tizen'">6.5</SupportedOSPlatformVersion>
         <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-        <Version>2.1.2</Version>
-        <PackageVersion>2.1.2</PackageVersion>
+        <Version>2.2.0</Version>
+        <PackageVersion>2.2.0</PackageVersion>
         <Authors>Raygun</Authors>
         <Company>Raygun</Company>
         <PackageReadmeFile>README.md</PackageReadmeFile>
@@ -106,7 +106,7 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.1" />
-        <PackageReference Include="Mindscape.Raygun4Net.NetCore" Version="11.0.3" />
+        <PackageReference Include="Mindscape.Raygun4Net.NetCore" Version="11.1.0" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net7.0-android'">


### PR DESCRIPTION
### v2.2.0
- Version bump to `Raygun4Net.NetCore v11.1.0`
  - Implements dynamic thread allocation when error spikes occurs
    - Fixes static thread allocation which caused performance issues on .NET Core and MAUI apps
  - Removes errors stuck in a 4xx loop when stored in the offline storage 
    - Edge case allowed for errors that should have been 4xx to put into offline storage and infinitely loop
    - Large errors would also make concurrent GC heap freed messages in the console