### PR TITLE
Raise defualt log level error

### DIFF
--- a/CHANGE-LOG.md
+++ b/CHANGE-LOG.md
@@ -1,5 +1,17 @@
 # Full Change Log for Raygun4Maui package
 
+### v2.2.3
+- Raise min log level to `Error` for the Raygun4Maui ILogger
+  - This is to prevent spamming of irrelevant log to Raygun
+
+### 2.2.2
+- Fix Attempting to JIT compile method while in AOT only mode for Swizzled Apple Native Timings
+
+### 2.2.1
+* Bump to v11.1.2 of Raygun4Net and add example of UnobservedTaskException
+  * UnobservedTaskException is now automatically unwrapped if there is only one exception in the AggregateException
+  * UnobservedTaskExceptions are now tagged as UnobservedTaskException instead of UnhandledException
+
 ### v2.2.0
 - Version bump to `Raygun4Net.NetCore v11.1.0`
   - Implements dynamic thread allocation when error spikes occurs

--- a/Raygun4Maui/Raygun4Maui.csproj
+++ b/Raygun4Maui/Raygun4Maui.csproj
@@ -106,7 +106,7 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.1" />
-        <PackageReference Include="Mindscape.Raygun4Net.NetCore" Version="11.1.2" />
+        <PackageReference Include="Mindscape.Raygun4Net.NetCore" Version="11.2.1" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net7.0-android'">

--- a/Raygun4Maui/Raygun4Maui.csproj
+++ b/Raygun4Maui/Raygun4Maui.csproj
@@ -16,8 +16,8 @@
         <TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</TargetPlatformMinVersion>
         <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'tizen'">6.5</SupportedOSPlatformVersion>
         <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-        <Version>2.2.2</Version>
-        <PackageVersion>2.2.2</PackageVersion>
+        <Version>2.2.3</Version>
+        <PackageVersion>2.2.3</PackageVersion>
         <Authors>Raygun</Authors>
         <Company>Raygun</Company>
         <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/Raygun4Maui/Raygun4Net.RaygunLogger/RaygunLoggerConfiguration.cs
+++ b/Raygun4Maui/Raygun4Net.RaygunLogger/RaygunLoggerConfiguration.cs
@@ -18,7 +18,7 @@ namespace Raygun4Net.RaygunLogger
         {
             SendDefaultTags = true;
             SendDefaultCustomData = true;
-            MinLogLevel = LogLevel.Debug;
+            MinLogLevel = LogLevel.Error;
             MaxLogLevel = LogLevel.Critical;
         }
     }


### PR DESCRIPTION
`Mindscape.Raygun4Net.Extensions.Logging` min log level is `Error`

Previously our min log level for the built in Raygun4Maui ILogger was set to `Debug`, this caused a lot of spam and slowdown of apps if they have hundreds of logs per second.

Because of this we are bumping the min log level to `Error`